### PR TITLE
Update main.py to download punkt_tab and solve this error

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ def ensure_nltk_data():
     nltk.download('stopwords', quiet=True)
     nltk.download('punkt', quiet=True)
     nltk.download('wordnet', quiet=True)
+    nltk.download('punkt_tab', quiet=True)
 
 # Initialize models
 image_inference = None


### PR DESCRIPTION
This solves this error, I was able to use the organizer, still however only with cpu.


raise LookupError(resource_not_found)
LookupError:
********************************************************************** Resource punkt_tab not found.
Please use the NLTK Downloader to obtain the resource:

>>> import nltk
>>> nltk.download('punkt_tab')

For more information see: https://www.nltk.org/data.html

Attempted to load tokenizers/punkt_tab/english/