### PR TITLE
add command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@ __pycache__/
 # Jupyter Notebook checkpoints
 .ipynb_checkpoints/
 
+# vscode folder
+.vscode/
+
 # Virtual environment folders
 env/
 venv/
+.venv/
 
 # Ignore log files and temporary files
 *.log
@@ -21,3 +25,6 @@ venv/
 # Ignore example output files
 organized_folder/
 operation_log.txt
+
+# Ignore test folder
+test/

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import os
 import time
+import getopt, sys
+import logging
 
 from file_utils import (
     display_directory_tree,
@@ -114,37 +116,106 @@ def get_yes_no(prompt):
         else:
             print("Please enter 'yes' or 'no'. To exit, type '/exit'.")
 
-def get_mode_selection():
-    """Prompt the user to select a mode."""
+MODE_OPTIONS = {
+    '1': 'content',
+    '2': 'date',
+    '3': 'type',
+    'content': 'content',
+    'date': 'date',
+    'type': 'type'
+}
+
+def get_mode_selection(response = None):
+    """Prompt the user to select a mode, or use provided response if valid."""
+    if response in MODE_OPTIONS:
+        return MODE_OPTIONS[response]
+    
     while True:
         print("Please choose the mode to organize your files:")
         print("1. By Content")
         print("2. By Date")
         print("3. By Type")
+        
         response = input("Enter 1, 2, or 3 (or type '/exit' to exit): ").strip()
+
         if response == '/exit':
             print("Exiting program.")
             exit()
-        elif response == '1':
-            return 'content'
-        elif response == '2':
-            return 'date'
-        elif response == '3':
-            return 'type'
-        else:
-            print("Invalid selection. Please enter 1, 2, or 3. To exit, type '/exit'.")
+
+        if response in MODE_OPTIONS:
+            return MODE_OPTIONS[response]
+        
+        print("Invalid selection. Please enter 1, 2, or 3. To exit, type '/exit'.")
+
+def process_command_line_arguments():
+    argumentList = sys.argv[1:]
+
+    options = "hv:i:o:c:"
+    long_options = ["help","verbose=", "input=", "output=", "clasification_mode="]
+
+    verbose = None
+    input_path = None
+    output_path = None
+    clasification_mode = None
+    try:
+        arguments, values = getopt.getopt(argumentList, options, long_options)
+    except getopt.error as err:
+        print(str(err))
+        sys.exit(2)
+    
+    print("Arguments: ", arguments)
+    print("Values: ", values)   
+    for currentArgument, currentValue in arguments:
+        if currentArgument in ("-h", "--help"):
+            print("Usage: python main.py [-h] [-v MODE] [-i INPUT] [-o OUTPUT] [-c CLASIFICATION_MODE]")
+            print("Options:")
+            print("  -h, --help           Show this help message and exit")
+            print("  -v, --verbose        Enable verbose mode.")
+            print("                       Optional value: 0 = silent, >0 = verbose level.")
+            print("                       Silent mode logs all outputs to a text file: operation_log.txt")
+            print("                       If not provided, it will be asked")
+            print("  -i, --input PATH     Specify the input directory (if not provided, it will be asked)")
+            print("  -o, --output PATH    Specify the destination directory (default: 'organized_folder' in input)")
+            print("  -c, --classification_mode CLASIFICATION_MODE    Specify the classification mode (default: 'None')")
+            print("                       Optional values: 1 = 'content', 2 = 'date', 3 = 'type'")
+
+            sys.exit(0)
+
+        if currentArgument in ("-v", "--verbose"):
+            verbose = currentValue
+        if currentArgument in ("-i", "--input"):
+            input_path = currentValue
+        if currentArgument in ("-o", "--output"):
+            output_path = currentValue
+        if currentArgument in ("-c", "--classification_mode"):
+            clasification_mode = currentValue
+
+    return verbose, input_path, output_path, clasification_mode
+
+
+def setup_logging(silent_mode: bool, log_file='operation_log.txt'):
+    level = logging.INFO
+    if silent_mode:
+        logging.basicConfig(filename=log_file, level=level)
+    else:
+        logging.basicConfig(level=level)
 
 def main():
     # Ensure NLTK data is downloaded efficiently and quietly
     ensure_nltk_data()
-
+    verbose, input_path, output_path, mode = process_command_line_arguments()
     # Start with dry run set to True
     dry_run = True
 
     # Display silent mode explanation before asking
     print("-" * 50)
     print("**NOTE: Silent mode logs all outputs to a text file instead of displaying them in the terminal.")
-    silent_mode = get_yes_no("Would you like to enable silent mode? (yes/no): ")
+    if verbose is None:
+        silent_mode = get_yes_no("Would you like to enable silent mode? (yes/no): ")
+    else: 
+        silent_mode = (verbose == '0') 
+        if silent_mode:
+            print(f"Silent mode enabled with verbose level: {verbose}")
     if silent_mode:
         log_file = 'operation_log.txt'
     else:
@@ -156,7 +227,8 @@ def main():
             print("-" * 50)
 
         # Get input and output paths once per directory
-        input_path = input("Enter the path of the directory you want to organize: ").strip()
+        if input_path is None:
+            input_path = input("Enter the path of the directory you want to organize: ").strip()
         while not os.path.exists(input_path):
             message = f"Input path {input_path} does not exist. Please enter a valid path."
             if silent_mode:
@@ -177,7 +249,8 @@ def main():
             print("-" * 50)
 
         # Default output path is a folder named "organized_folder" in the same directory as the input path
-        output_path = input("Enter the path to store organized files and folders (press Enter to use 'organized_folder' in the input directory): ").strip()
+        if output_path is None:
+            output_path = input("Enter the path to store organized files and folders (press Enter to use 'organized_folder' in the input directory): ").strip()
         if not output_path:
             # Get the parent directory of the input path and append 'organized_folder'
             output_path = os.path.join(os.path.dirname(input_path), 'organized_folder')
@@ -212,7 +285,7 @@ def main():
 
         # Loop for selecting sorting methods
         while True:
-            mode = get_mode_selection()
+            mode = get_mode_selection(mode)
 
             if mode == 'content':
                 # Proceed with content mode
@@ -322,6 +395,7 @@ def main():
                 # Ask if the user wants to try another sorting method
                 another_sort = get_yes_no("Would you like to choose another sorting method? (yes/no): ")
                 if another_sort:
+                    mode = None # Reset mode
                     continue  # Loop back to mode selection
                 else:
                     print("Operation canceled by the user.")

--- a/main.py
+++ b/main.py
@@ -151,12 +151,12 @@ def process_command_line_arguments():
     argumentList = sys.argv[1:]
 
     options = "hv:i:o:c:"
-    long_options = ["help","verbose=", "input=", "output=", "clasification_mode="]
+    long_options = ["help","verbose=", "input=", "output=", "classification_mode="]
 
     verbose = None
     input_path = None
     output_path = None
-    clasification_mode = None
+    classification_mode = None
     try:
         arguments, values = getopt.getopt(argumentList, options, long_options)
     except getopt.error as err:
@@ -167,7 +167,7 @@ def process_command_line_arguments():
     print("Values: ", values)   
     for currentArgument, currentValue in arguments:
         if currentArgument in ("-h", "--help"):
-            print("Usage: python main.py [-h] [-v MODE] [-i INPUT] [-o OUTPUT] [-c CLASIFICATION_MODE]")
+            print("Usage: python main.py [-h] [-v MODE] [-i INPUT] [-o OUTPUT] [-c CLASSIFICATION_MODE]")
             print("Options:")
             print("  -h, --help           Show this help message and exit")
             print("  -v, --verbose        Enable verbose mode.")
@@ -176,7 +176,7 @@ def process_command_line_arguments():
             print("                       If not provided, it will be asked")
             print("  -i, --input PATH     Specify the input directory (if not provided, it will be asked)")
             print("  -o, --output PATH    Specify the destination directory (default: 'organized_folder' in input)")
-            print("  -c, --classification_mode CLASIFICATION_MODE    Specify the classification mode (default: 'None')")
+            print("  -c, --classification_mode CLASSIFICATION_MODE    Specify the classification mode (default: 'None')")
             print("                       Optional values: 1 = 'content', 2 = 'date', 3 = 'type'")
 
             sys.exit(0)
@@ -188,9 +188,9 @@ def process_command_line_arguments():
         if currentArgument in ("-o", "--output"):
             output_path = currentValue
         if currentArgument in ("-c", "--classification_mode"):
-            clasification_mode = currentValue
+            classification_mode = currentValue
 
-    return verbose, input_path, output_path, clasification_mode
+    return verbose, input_path, output_path, classification_mode
 
 
 def setup_logging(silent_mode: bool, log_file='operation_log.txt'):


### PR DESCRIPTION
Added support for command line arguments to enable faster and more flexible execution. If no arguments (or only some) are provided, the program will fall back to using the original `input()` prompts.

**Why:**
Using command line arguments provides several benefits:

- Enables easier debugging and testing
- Supports automation and scripting
- Avoids blocking interactive prompts that are not friendly for non-interactive environments (e.g., CI/CD, batch scripts)

This change maintains backward compatibility by preserving interactive prompts when needed.

Example of a launch.json:
```

{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Run with CLI args",
      "type": "debugpy",
      "request": "launch",
      "program": "${workspaceFolder}/main.py",
      "console": "integratedTerminal",
      "args": [
        "-v", "1",
        "-i", "${workspaceFolder}/sample_data",
        "-o", "${workspaceFolder}/organized_output",
        "-c", "1"
      ]
    }
  ]
}
```
